### PR TITLE
Prevent early channel close

### DIFF
--- a/internal/pipeline/controller.go
+++ b/internal/pipeline/controller.go
@@ -90,16 +90,18 @@ func (p *Pipeline) runOutputs(ctx context.Context, source chan types.Media) erro
 
 	wg.Add(1)
 	go func(_ context.Context, in <-chan types.Media, outs []chan<- types.Media) {
+		var wgOut sync.WaitGroup
 		defer wg.Done()
 		for m := range source {
 			for _, out := range outs {
-				wg.Add(1)
+				wgOut.Add(1)
 				go func(_ context.Context, i types.Media, o chan<- types.Media) {
-					defer wg.Done()
+					defer wgOut.Done()
 					o <- i
 				}(ctx, m, out)
 			}
 		}
+		wgOut.Wait()
 		for _, o := range outs {
 			close(o)
 		}


### PR DESCRIPTION
I was just testing this out and ran into a sporadic bug when testing against a single file in dry-run mode.

The `close` call was executing before the items had all been written.

Error message:

```
panic: send on closed channel

goroutine 31 [running]:
github.com/rbtr/pachinko/internal/pipeline.(*Pipeline).runOutputs.func2.1(0xc000481910, 0xbcd6e0, 0xc0003c0d00, 0xc00024e380, 0x6b, 0xc0004ec500, 0x38, 0xae0599, 0x5, 0xadec68, ...)
	/.../pachinko/internal/pipeline/controller.go:99 +0xa0
created by github.com/rbtr/pachinko/internal/pipeline.(*Pipeline).runOutputs.func2
	/.../pachinko/internal/pipeline/controller.go:97 +0x141
```