### PR TITLE
let outputs inheret cfgs from root

### DIFF
--- a/docs/examples/pachinko.yaml
+++ b/docs/examples/pachinko.yaml
@@ -8,7 +8,6 @@ log-level: "info"
 outputs:
 - name: stdout
 - create-dirs: true
-  dry-run: false
   name: path-mover
   overwrite: false
 - authfile: "/etc/pachinko/trakt"

--- a/internal/config/sort.go
+++ b/internal/config/sort.go
@@ -48,6 +48,10 @@ func (c *Sort) ConfigurePipeline(pipe *pipeline.Pipeline) error {
 		}
 	}
 
+	ocfg := output.Config{
+		DryRun: c.DryRun,
+	}
+
 	for _, p := range c.Outputs {
 		if name, ok := p["name"]; ok {
 			if initializer, ok := output.Registry[name.(string)]; ok {
@@ -55,7 +59,7 @@ func (c *Sort) ConfigurePipeline(pipe *pipeline.Pipeline) error {
 				if err := mapstructure.Decode(p, plugin); err != nil {
 					return err
 				}
-				if err := plugin.Init(c.ctx); err != nil {
+				if err := plugin.Init(c.ctx, ocfg); err != nil {
 					return err
 				}
 				pipe.WithOutputs(plugin)
@@ -63,8 +67,8 @@ func (c *Sort) ConfigurePipeline(pipe *pipeline.Pipeline) error {
 		}
 	}
 
-	deleter := internalout.NewDeleter(c.DryRun)
-	if err := deleter.Init(c.ctx); err != nil {
+	deleter := &internalout.Deleter{}
+	if err := deleter.Init(c.ctx, ocfg); err != nil {
 		return err
 	}
 	pipe.WithOutputs(deleter)

--- a/plugin/input/path.go
+++ b/plugin/input/path.go
@@ -64,7 +64,7 @@ func (p *FilePathInput) Consume(sink chan<- types.Item) {
 func init() {
 	Register("filepath", func() Input {
 		return &FilePathInput{
-			SrcDir: "./src",
+			SrcDir: "/src",
 		}
 	})
 }

--- a/plugin/output/logger.go
+++ b/plugin/output/logger.go
@@ -17,7 +17,7 @@ import (
 // Logger is a noop logging output used for dry-runs and testing
 type Logger struct{}
 
-func (*Logger) Init(context.Context) error {
+func (*Logger) Init(context.Context, Config) error {
 	return nil
 }
 

--- a/plugin/output/path_mover.go
+++ b/plugin/output/path_mover.go
@@ -22,16 +22,18 @@ import (
 // some options like creating dirs or overwriting existing dests
 type FilepathMover struct {
 	CreateDirs bool `mapstructure:"create-dirs"`
-	DryRun     bool `mapstructure:"dry-run"`
 	Overwrite  bool `mapstructure:"overwrite"`
+
+	dryRun bool
 }
 
-func (*FilepathMover) Init(context.Context) error {
+func (mv *FilepathMover) Init(ctx context.Context, cfg Config) error {
+	mv.dryRun = cfg.DryRun
 	return nil
 }
 
 func (mv *FilepathMover) mkdir(dir string) error {
-	if mv.DryRun {
+	if mv.dryRun {
 		log.Infof("move_output: (DRY_RUN) mkdir %s", dir)
 		return nil
 	}
@@ -44,7 +46,7 @@ func (mv *FilepathMover) mkdir(dir string) error {
 // if src and dest are on different volumes, it will error with a cross-device
 // link message
 func (mv *FilepathMover) rename(src, dest string) error {
-	if mv.DryRun {
+	if mv.dryRun {
 		log.Infof("move_output: (DRY_RUN) rename %s -> %s", src, dest)
 		return nil
 	}
@@ -56,7 +58,7 @@ func (mv *FilepathMover) rename(src, dest string) error {
 // should only be used to move data between volumes since rename is always
 // faster within the filesystem boundary
 func (mv *FilepathMover) move(src, dest string) error {
-	if mv.DryRun {
+	if mv.dryRun {
 		log.Infof("move_output: (DRY_RUN) copy %s -> %s", src, dest)
 		return nil
 	}
@@ -129,8 +131,8 @@ func init() {
 	Register("path-mover", func() Output {
 		return &FilepathMover{
 			CreateDirs: true,
-			DryRun:     true,
 			Overwrite:  false,
+			dryRun:     true,
 		}
 	})
 }

--- a/plugin/output/trakt_collector.go
+++ b/plugin/output/trakt_collector.go
@@ -30,7 +30,7 @@ type TraktCollector struct {
 // Init reads the authfile, creates a client, refreshes the
 // credentials, and writes them back to the authfile. Any failures
 // will return an error.
-func (t *TraktCollector) Init(ctx context.Context) error {
+func (t *TraktCollector) Init(ctx context.Context, cfg Config) error {
 	auth, err := internaltrakt.ReadAuthFile(t.Authfile)
 	if err != nil {
 		return err

--- a/plugin/output/types.go
+++ b/plugin/output/types.go
@@ -20,10 +20,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Config is common/general output tunables
+type Config struct {
+	DryRun bool
+}
+
 // Output is plugin interface to handle the result
 type Output interface {
 	Receive(<-chan types.Item)
-	Init(context.Context) error
+	Init(context.Context, Config) error
 }
 
 var Registry map[string](func() Output) = map[string](func() Output){}

--- a/plugin/processor/post/movie_path_solver.go
+++ b/plugin/processor/post/movie_path_solver.go
@@ -59,7 +59,7 @@ func (p *MoviePathSolver) Process(in <-chan types.Item, out chan<- types.Item) {
 func init() {
 	processor.Register(processor.Post, "movie-path-solver", func() processor.Processor {
 		return &MoviePathSolver{
-			DestDir:      "dest",
+			DestDir:      "/dest",
 			MovieDirs:    true,
 			MoviesPrefix: "movies",
 			OutputFormat: "not-implemented",

--- a/plugin/processor/post/tv_path_solver.go
+++ b/plugin/processor/post/tv_path_solver.go
@@ -80,7 +80,7 @@ func (p *TVPathSolver) Process(in <-chan types.Item, out chan<- types.Item) {
 func init() {
 	processor.Register(processor.Post, "tv-path-solver", func() processor.Processor {
 		return &TVPathSolver{
-			DestDir:      "dest",
+			DestDir:      "/dest",
 			EpisodeNames: false,
 			TVPrefix:     "tv",
 			SeasonDirs:   true,


### PR DESCRIPTION
this is a breaking change as it removes the dry-run options from output configs